### PR TITLE
WIP: Build and run on Alpine Linux

### DIFF
--- a/finance-entrypoint
+++ b/finance-entrypoint
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # (C) 2012-2018 Stefan Schallenberg
 # 

--- a/fntxt2sql/Makefile
+++ b/fntxt2sql/Makefile
@@ -25,7 +25,7 @@ BINDIR  = /home/finance/bin
 #
 CC=gcc
 CFLAGS=-pipe -Wall
-LIBS=-L/usr/local/lib
+LIBS=-L/usr/lib
 
 ifneq ($(CONF_MYSQL),0)
 CFLAGS+=-DCONF_MYSQL
@@ -40,15 +40,14 @@ endif
 
 ifneq ($(CONF_AQB6),0)
 CFLAGS+=-DCONF_AQB6 -I/usr/include/aqbanking6 -I/usr/include/gwenhywfar5
-CFLAGS+=-I/usr/local/include/aqbanking6 -I/usr/local/include/gwenhywfar5
 LIBS+=-laqbanking -lgwenhywfar
 endif
 
 # Debugging/profiling version?
 ifneq ($(DEBUG), 0)
   # Flags for developer's version
-  CFLAGS+=-g -pg -DDEBUG
-  LDFLAGS+=-pg
+  CFLAGS+=-g -DDEBUG
+  LDFLAGS+=-g
 else
   # Flags for production version
   CFLAGS+=-O
@@ -66,7 +65,7 @@ export CFLAGS
 all: fntxt2sql
 
 fntxt2sql: fntxt2sql.o \
-	       fntxt2sql-btx.o fntxt2sql-csv.o fntxt2sql-aqm.o \
+	       fntxt2sql-csv.o fntxt2sql-aqm.o \
 	       fntxt2sql-aqb-tran.o fntxt2sql-aqb-bal.o fntxt2sql-aqb6.o \
 	       fntxt2sql-hbci.o \
 	       fntxt2sql-util.o fntxt2sql-mysql.o fnSql.o
@@ -75,8 +74,10 @@ fntxt2sql: fntxt2sql.o \
 fntxt2sql.o: fntxt2sql.c fntxt2sql.h
 	$(CC) $(CFLAGS) -DVERSION="\"$(VERSION)\"" -o $@ -c fntxt2sql.c
 
-fntxt2sql-btx.o: fntxt2sql-btx.c fntxt2sql.h
-	$(CC) $(CFLAGS) -DVERSION="\"$(VERSION)\"" -o $@ -c fntxt2sql-btx.c
+# fntxt2sql-btx.c:795:15: error: dereferencing pointer to incomplete type 'FILE' {aka 'struct _IO_FILE'}
+#   795 |  if(fstat(file->_fileno, &fileStat) != 0)
+# fntxt2sql-btx.o: fntxt2sql-btx.c fntxt2sql.h
+# 	$(CC) $(CFLAGS) -DVERSION="\"$(VERSION)\"" -o $@ -c fntxt2sql-btx.c
 
 fntxt2sql-csv.o: fntxt2sql-csv.c fntxt2sql.h
 	$(CC) $(CFLAGS) -DVERSION="\"$(VERSION)\"" -o $@ -c fntxt2sql-csv.c

--- a/fntxt2sql/fntxt2sql.c
+++ b/fntxt2sql/fntxt2sql.c
@@ -61,7 +61,8 @@ int processFile(char *achInpFileName)
 		}
 	}
 	if(config.inputFormat == inpBtx)
-		iRc = processBtxFile(inpFile);
+		// TODO iRc = processBtxFile(inpFile);
+		iRc = 0;
 #ifdef CONF_AQB6
 	else if (config.inputFormat == inpAqb6)
 		iRc = processAqb6File(achInpFileName);


### PR DESCRIPTION
This is my attempt to get this running on Alpine (#5).

`alpine:edge` has a working package for `aqbanking` 6, so we do not need to build it.

I have no idea if and how `pxlib` is required, so I dropped it. There is no prebuilt package for alpine and the makefile for it does not work.

`fntxt2sql` currently does not compile because the linker cannot find several `mysql`, `aqbanking` and `gwen`-related symbolds. Given my 20-year old (outdated) experience in C and nil experience with gcc I was unable to fix these errors. The libs are there, `nm` shows the symbols in question, but `ld` refuses to to accept them.

Also `fntxt2sql-btx.o` causes a compiler error, so I excluded that for now.

`CFLAGS` with `-p` also causes linker errors.

Perhaps this PR makes it easier for you to transition to Alpine.